### PR TITLE
All base R functionals: drop last dependency foreach

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,4 @@
 export(opus_file)
 export(opus_read)
 export(opus_read_raw)
-importFrom(foreach,"%do%")
-importFrom(foreach,"%dopar%")
 importFrom(stats,setNames)


### PR DESCRIPTION
Hi Pierre,
I managed to cut down speed of parsing the example file by another half! Didn't expect this to happen.
Output remains identical. Plus we have a zero-dependency on external packages.
![opusreader_foreach-cleaning](https://user-images.githubusercontent.com/21625034/115109932-f9c10300-9f78-11eb-8e03-138eb8f0b3fc.png)

Cheers,
Philipp
