### PR TITLE
Add argument for rounding wns (x-unit values) to number of decimal places when `simplify = TRUE`

### DIFF
--- a/R/opus_read_file.R
+++ b/R/opus_read_file.R
@@ -14,8 +14,8 @@
 #' \code{"IgSm"} (interferogram of the sample measurement) and \code{"IgRf"}
 #' (interferogram of the reference measurement).
 #' @param simplify Logical (defaults \code{FALSE}): if set to \code{TRUE}, returns a much smaller list. The first object of that list (\code{wavenumbers}) is the wavenumbers of the first file read. The second object (\code{spectra}) is a matrix of the corresponding spectra. Especially useful when passing more than one file to the \code{file} option, for example to read a suite of spectral file directly into a matrix.
-#' @param simplify_xdigits Integer that specifies the number of decimal places used to round 
-#' the wavenumbers (x-variables) if \code{simplify = TRUE}.
+#' @param wns_digits Integer that specifies the number of decimal places used to round 
+#' the wavenumbers (values of x-variables) if \code{simplify = TRUE}.
 #' @param progress Logical (defaults \code{TRUE}) whether a message is
 #' printed when an OPUS binary file is parsed into an R list entry.
 #' @param atm_comp_minus4offset Logical whether spectra after atmospheric
@@ -35,7 +35,7 @@ opus_read <- function(
   file,
   extract = "spc",
   simplify = FALSE,
-  simplify_xdigits = 1L,
+  wns_digits = 1L,
   progress = TRUE,
   atm_comp_minus4offset = FALSE
 ) {
@@ -86,7 +86,7 @@ opus_read <- function(
       # Fetch wavenumbers
       wns <- lapply(
         res,
-        function(x) round(x$wavenumbers, digits = simplify_xdigits)
+        function(x) round(x$wavenumbers, digits = wns_digits)
       )
 
       # Arbitrarily take the first rounded WN as the reference one

--- a/R/opus_read_file.R
+++ b/R/opus_read_file.R
@@ -14,6 +14,8 @@
 #' \code{"IgSm"} (interferogram of the sample measurement) and \code{"IgRf"}
 #' (interferogram of the reference measurement).
 #' @param simplify Logical (defaults \code{FALSE}): if set to \code{TRUE}, returns a much smaller list. The first object of that list (\code{wavenumbers}) is the wavenumbers of the first file read. The second object (\code{spectra}) is a matrix of the corresponding spectra. Especially useful when passing more than one file to the \code{file} option, for example to read a suite of spectral file directly into a matrix.
+#' @param simplify_xdigits Integer that specifies the number of decimal places used to round 
+#' the wavenumbers (x-variables) if \code{simplify = TRUE}.
 #' @param progress Logical (defaults \code{TRUE}) whether a message is
 #' printed when an OPUS binary file is parsed into an R list entry.
 #' @param atm_comp_minus4offset Logical whether spectra after atmospheric
@@ -33,6 +35,7 @@ opus_read <- function(
   file,
   extract = "spc",
   simplify = FALSE,
+  simplify_xdigits = 1L,
   progress = TRUE,
   atm_comp_minus4offset = FALSE
 ) {
@@ -81,7 +84,10 @@ opus_read <- function(
       }
 
       # Fetch wavenumbers
-      wns <- lapply(res, function(x) x$wavenumbers)
+      wns <- lapply(
+        res,
+        function(x) round(x$wavenumbers, digits = simplify_xdigits)
+      )
 
       # Arbitrarily take the first rounded WN as the reference one
       wn_ref <- wns[[1]]
@@ -103,6 +109,7 @@ opus_read <- function(
 
           # Linear interpolation to get spectra at rounded wavenumber
           s <- approx(x = x$wavenumbers, y = x[[id]], xout = wn_ref, method = "linear")$y
+          names(s) <- as.character(wn_ref)
 
           return(s)
         })


### PR DESCRIPTION
#3 
* This implements user control for rounding the wavenumbers when simplified matrix output is demanded.
* Plus it fixes the missing column names in the collated matrix of all spectra in files.

Current main branch:
``` r
library("opusreader")

fp <- opus_file()
s_default <- opus_read(rep(fp, 10L))
s_simplified <- opus_read(rep(fp, 10L), simplify = TRUE)

dim(s_default[[1]]$spc)
#> [1]    1 4819
dim(s_simplified$spectra)
#> [1]   10 4819
colnames(s_default[[1]]$spc)[1:5]
#> [1] "7498.3" "7496.9" "7495.4" "7494"   "7492.6"
colnames(s_simplified$spectra)[1:5]
#> NULL
```

<sup>Created on 2021-04-28 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>
 

After commit:
``` r
library("opusreader")

fp <- opus_file()
s_default <- opus_read(rep(fp, 10L))
s_simplified <- opus_read(rep(fp, 10L), simplify = TRUE)
s_simplified_round0 <- opus_read(rep(fp, 10L), simplify = TRUE, simplify_xdigits = 0L)

dim(s_default[[1]]$spc)
#> [1]    1 4819
dim(s_simplified$spectra)
#> [1]   10 4819
colnames(s_default[[1]]$spc)[1:5]
#> [1] "7498.3" "7496.9" "7495.4" "7494"   "7492.6"
colnames(s_simplified$spectra)[1:5]
#> [1] "7498.3" "7496.9" "7495.4" "7494"   "7492.6"
colnames(s_simplified_round0$spectra)[1:5]
#> [1] "7498" "7497" "7495" "7494" "7493"
```

<sup>Created on 2021-04-28 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>
