### PR TITLE
Rename spectra without compensation for atmospheric gases

### DIFF
--- a/R/opus_read_file.R
+++ b/R/opus_read_file.R
@@ -7,7 +7,7 @@
 #' @param type Character vector of spectra types to extract from OPUS binary
 #' file. Default is `"spec"`, which will extract the final spectra, e.g.
 #' expressed in absorbance (named `AB` in Bruker OPUS programs). Possible
-#' additional values for the character vector supplied to `type` are `"spec_no_atm_comp"` (spectrum of the sample without compensation for atmospheric gases H[2]O and/or CO[2]),
+#' additional values for the character vector supplied to `type` are `"spec_no_atm_comp"` (spectrum of the sample without compensation for atmospheric gases, water vapor and/or carbon dioxide),
 #' `"sc_sample"` (single channel spectrum of the sample measurement), `"sc_ref"` (single channel spectrum of the reference measurement),
 #' `"ig_sample"` (interferogram of the sample measurement) and `"ig_ref"`
 #' (interferogram of the reference measurement).

--- a/R/opus_read_file.R
+++ b/R/opus_read_file.R
@@ -7,7 +7,7 @@
 #' @param type Character vector of spectra types to extract from OPUS binary
 #' file. Default is `"spec"`, which will extract the final spectra, e.g.
 #' expressed in absorbance (named `AB` in Bruker OPUS programs). Possible
-#' additional values for the character vector supplied to `type` are `"spec_no_bc"` (spectrum of the sample without background correction),
+#' additional values for the character vector supplied to `type` are `"spec_no_atm_comp"` (spectrum of the sample without compensation for atmospheric gases H[2]O and/or CO[2]),
 #' `"sc_sample"` (single channel spectrum of the sample measurement), `"sc_ref"` (single channel spectrum of the reference measurement),
 #' `"ig_sample"` (interferogram of the sample measurement) and `"ig_ref"`
 #' (interferogram of the reference measurement).
@@ -38,12 +38,12 @@
 #'  - If `simplify = FALSE` (default), `opus_read()` returns a list of 10 elements:
 #'     - `metadata`: a `data.frame` containing metadata from the OPUS file
 #'     - `spec` If `"spec"` was requested in the `type` option, a matrix of the spectrum of the sample (otherwise set to `NULL`).
-#'     - `spec_no_bc` If `"spec_no_bc"` was requested in the `type` option, a matrix of the spectrum of the sample without background correction (otherwise set to `NULL`).
+#'     - `spec_no_atm_comp` If `"spec_no_atm_comp"` was requested in the `type` option, a matrix of the spectrum of the sample without background compensation (otherwise set to `NULL`).
 #'     - `sc_sample` If `"sc_sample"` was requested in the `type` option, a matrix of the single channel spectrum of the sample (otherwise set to `NULL`).
 #'     - `sc_ref` If `"sc_ref"` was requested in the `type` option, a matrix of the single channel spectrum of the reference (otherwise set to `NULL`).
 #'     - `ig_sample` If `"ig_sample"` was requested in the `type` option, a matrix of the interferogram of the sample (otherwise set to `NULL`).
 #'     - `ig_ref`  If `"ig_ref"` was requested in the `type` option, a matrix of the interferogram of the reference (otherwise set to `NULL`).
-#'     - `wavenumbers` If `"spec"` or `"spec_no_bc"` was requested in the `type` option, a numeric vector of the wavenumbers of the spectrum of the sample (otherwise set to `NULL`).
+#'     - `wavenumbers` If `"spec"` or `"spec_no_atm_comp"` was requested in the `type` option, a numeric vector of the wavenumbers of the spectrum of the sample (otherwise set to `NULL`).
 #'     - `wavenumbers_sc_sample` If `"sc_sample"` was requested in the `type` option, a numeric vector of the wavenumbers of the single channel spectrum of the sample (otherwise set to `NULL`).
 #'     - `wavenumbers_sc_ref` If `"sc_ref"` was requested in the `type` option, a numeric vector of the wavenumbers of the single channel spectrum of the reference (otherwise set to `NULL`).
 
@@ -130,7 +130,7 @@ opus_read <- function(
 
           id <- switch(type,
             spec = "spec",
-            spec_no_bc = "spec_no_bc",
+            spec_no_atm_comp = "spec_no_atm_comp",
             sc_sample = "sc_sample",
             sc_ref = "sc_ref",
             ig_sample = "ig_sample",
@@ -140,7 +140,7 @@ opus_read <- function(
           # Grab correct wavenumbers for interpolation
           wn <- switch(type,
             spec = x$wavenumbers,
-            spec_no_bc = x$wavenumbers,
+            spec_no_atm_comp = x$wavenumbers,
             sc_sample = x$wavenumbers_sc_sample,
             sc_ref = x$wavenumbers_sc_ref,
             ig_sample = x$wavenumbers_sc_sample,

--- a/R/opus_read_raw.R
+++ b/R/opus_read_raw.R
@@ -8,7 +8,7 @@
 #' @param type Character vector of spectra types to extract from OPUS binary
 #' file. Default is `"spec"`, which will extract the final spectra, e.g.
 #' expressed in absorbance (named `AB` in Bruker OPUS programs). Possible
-#' additional values for the character vector supplied to `type` are `"spec_no_atm_comp"` (spectrum of the sample without compensation for atmospheric gases H[2]O and/or CO[2]),
+#' additional values for the character vector supplied to `type` are `"spec_no_atm_comp"` (spectrum of the sample without compensation for atmospheric gases, water vapor and/or carbon dioxide),
 #' `"sc_sample"` (single channel spectrum of the sample measurement),
 #' `"sc_ref"` (single channel spectrum of the reference measurement),
 #' `"ig_sample"` (interferogram of the sample measurement) and `"ig_ref"`

--- a/R/opus_read_raw.R
+++ b/R/opus_read_raw.R
@@ -8,7 +8,7 @@
 #' @param type Character vector of spectra types to extract from OPUS binary
 #' file. Default is `"spec"`, which will extract the final spectra, e.g.
 #' expressed in absorbance (named `AB` in Bruker OPUS programs). Possible
-#' additional values for the character vector supplied to `type` are `"spec_no_bc"` (spectrum of the sample without background correction),
+#' additional values for the character vector supplied to `type` are `"spec_no_atm_comp"` (spectrum of the sample without compensation for atmospheric gases H[2]O and/or CO[2]),
 #' `"sc_sample"` (single channel spectrum of the sample measurement),
 #' `"sc_ref"` (single channel spectrum of the reference measurement),
 #' `"ig_sample"` (interferogram of the sample measurement) and `"ig_ref"`
@@ -29,12 +29,12 @@
 #' @return a list of 10 elements:
 #'     - `metadata`: a `data.frame` containing metadata from the OPUS file
 #'     - `spec` If `"spec"` was requested in the `type` option, a matrix of the spectrum of the sample (otherwise set to `NULL`).
-#'     - `spec_no_bc` If `"spec_no_bc"` was requested in the `type` option, a matrix of the spectrum of the sample without background correction (otherwise set to `NULL`).
+#'     - `spec_no_atm_comp` If `"spec_no_atm_comp"` was requested in the `type` option, a matrix of the spectrum of the sample without atmospheric compensation (otherwise set to `NULL`).
 #'     - `sc_sample` If `"sc_sample"` was requested in the `type` option, a matrix of the single channel spectrum of the sample (otherwise set to `NULL`).
 #'     - `sc_ref` If `"sc_ref"` was requested in the `type` option, a matrix of the single channel spectrum of the reference (otherwise set to `NULL`).
 #'     - `ig_sample` If `"ig_sample"` was requested in the `type` option, a matrix of the interferogram of the sample (otherwise set to `NULL`).
 #'     - `ig_ref`  If `"ig_ref"` was requested in the `type` option, a matrix of the interferogram of the reference (otherwise set to `NULL`).
-#'     - `wavenumbers` If `"spec"` or `"spec_no_bc"` was requested in the `type` option, a numeric vector of the wavenumbers of the spectrum of the sample (otherwise set to `NULL`).
+#'     - `wavenumbers` If `"spec"` or `"spec_no_atm_comp"` was requested in the `type` option, a numeric vector of the wavenumbers of the spectrum of the sample (otherwise set to `NULL`).
 #'     - `wavenumbers_sc_sample` If `"sc_sample"` was requested in the `type` option, a numeric vector of the wavenumbers of the single channel spectrum of the sample (otherwise set to `NULL`).
 #'     - `wavenumbers_sc_ref` If `"sc_ref"` was requested in the `type` option, a numeric vector of the wavenumbers of the single channel spectrum of the reference (otherwise set to `NULL`).
 #'
@@ -52,7 +52,7 @@ opus_read_raw <- function(
   # Silently support and convert the default Bruker values
   type <- switch (type,
     "spc" = "spec", # for backwards compatibility
-    "spc_nocomp" = "spec_no_bc", # for backwards compatibility
+    "spc_nocomp" = "spec_no_atm_comp", # for backwards compatibility
     "ScSm" = "sc_sample",
     "ScRf" = "sc_ref",
     "IgSm" = "ig_sample",
@@ -61,7 +61,7 @@ opus_read_raw <- function(
   )
 
   # Sanity check on `type`
-  if (!all(type %in% c("spec", "spec_no_bc", "sc_sample", "sc_ref", "ig_sample", "ig_ref"))) {
+  if (!all(type %in% c("spec", "spec_no_atm_comp", "sc_sample", "sc_ref", "ig_sample", "ig_ref"))) {
     stop("Invalid value for the `type` option.", call. = FALSE)
   }
 
@@ -460,7 +460,7 @@ opus_read_raw <- function(
   } else {
     list(
       spc_idx = which_AB,
-      spc_code = c("spec_no_bc", "spec")
+      spc_code = c("spec_no_atm_comp", "spec")
     )
   }
 
@@ -899,11 +899,11 @@ opus_read_raw <- function(
       } else {
         NULL
       },
-    'spec_no_bc' = if ("spec_no_bc" %in% type) {
-        if ("spec_no_bc" %in% names(spc_m)) {
-          spc_m[["spec_no_bc"]]
+    'spec_no_atm_comp' = if ("spec_no_atm_comp" %in% type) {
+        if ("spec_no_atm_comp" %in% names(spc_m)) {
+          spc_m[["spec_no_atm_comp"]]
         } else {
-          warning("No 'spec_no_bc' spectra found", call. = FALSE)
+          warning("No 'spec_no_atm_comp' spectra found", call. = FALSE)
           NULL
         }
     } else {

--- a/man/opus_read.Rd
+++ b/man/opus_read.Rd
@@ -19,7 +19,7 @@ opus_read(
 \item{type}{Character vector of spectra types to extract from OPUS binary
 file. Default is \code{"spec"}, which will extract the final spectra, e.g.
 expressed in absorbance (named \code{AB} in Bruker OPUS programs). Possible
-additional values for the character vector supplied to \code{type} are \code{"spec_no_atm_comp"} (spectrum of the sample without compensation for atmospheric gases H\link{2}O and/or CO\link{2}),
+additional values for the character vector supplied to \code{type} are \code{"spec_no_atm_comp"} (spectrum of the sample without compensation for atmospheric gases, water vapor and/or carbon dioxide),
 \code{"sc_sample"} (single channel spectrum of the sample measurement), \code{"sc_ref"} (single channel spectrum of the reference measurement),
 \code{"ig_sample"} (interferogram of the sample measurement) and \code{"ig_ref"}
 (interferogram of the reference measurement).}

--- a/man/opus_read.Rd
+++ b/man/opus_read.Rd
@@ -19,7 +19,7 @@ opus_read(
 \item{type}{Character vector of spectra types to extract from OPUS binary
 file. Default is \code{"spec"}, which will extract the final spectra, e.g.
 expressed in absorbance (named \code{AB} in Bruker OPUS programs). Possible
-additional values for the character vector supplied to \code{type} are \code{"spec_no_bc"} (spectrum of the sample without background correction),
+additional values for the character vector supplied to \code{type} are \code{"spec_no_atm_comp"} (spectrum of the sample without compensation for atmospheric gases H\link{2}O and/or CO\link{2}),
 \code{"sc_sample"} (single channel spectrum of the sample measurement), \code{"sc_ref"} (single channel spectrum of the reference measurement),
 \code{"ig_sample"} (interferogram of the sample measurement) and \code{"ig_ref"}
 (interferogram of the reference measurement).}
@@ -46,12 +46,12 @@ The output of \code{opus_read()} depends on the value of the \code{simplify} opt
 \itemize{
 \item \code{metadata}: a \code{data.frame} containing metadata from the OPUS file
 \item \code{spec} If \code{"spec"} was requested in the \code{type} option, a matrix of the spectrum of the sample (otherwise set to \code{NULL}).
-\item \code{spec_no_bc} If \code{"spec_no_bc"} was requested in the \code{type} option, a matrix of the spectrum of the sample without background correction (otherwise set to \code{NULL}).
+\item \code{spec_no_atm_comp} If \code{"spec_no_atm_comp"} was requested in the \code{type} option, a matrix of the spectrum of the sample without background compensation (otherwise set to \code{NULL}).
 \item \code{sc_sample} If \code{"sc_sample"} was requested in the \code{type} option, a matrix of the single channel spectrum of the sample (otherwise set to \code{NULL}).
 \item \code{sc_ref} If \code{"sc_ref"} was requested in the \code{type} option, a matrix of the single channel spectrum of the reference (otherwise set to \code{NULL}).
 \item \code{ig_sample} If \code{"ig_sample"} was requested in the \code{type} option, a matrix of the interferogram of the sample (otherwise set to \code{NULL}).
 \item \code{ig_ref}  If \code{"ig_ref"} was requested in the \code{type} option, a matrix of the interferogram of the reference (otherwise set to \code{NULL}).
-\item \code{wavenumbers} If \code{"spec"} or \code{"spec_no_bc"} was requested in the \code{type} option, a numeric vector of the wavenumbers of the spectrum of the sample (otherwise set to \code{NULL}).
+\item \code{wavenumbers} If \code{"spec"} or \code{"spec_no_atm_comp"} was requested in the \code{type} option, a numeric vector of the wavenumbers of the spectrum of the sample (otherwise set to \code{NULL}).
 \item \code{wavenumbers_sc_sample} If \code{"sc_sample"} was requested in the \code{type} option, a numeric vector of the wavenumbers of the single channel spectrum of the sample (otherwise set to \code{NULL}).
 \item \code{wavenumbers_sc_ref} If \code{"sc_ref"} was requested in the \code{type} option, a numeric vector of the wavenumbers of the single channel spectrum of the reference (otherwise set to \code{NULL}).
 }

--- a/man/opus_read_raw.Rd
+++ b/man/opus_read_raw.Rd
@@ -12,7 +12,7 @@ opus_read_raw(rw, type = "spec", atm_comp_minus4offset = FALSE)
 \item{type}{Character vector of spectra types to extract from OPUS binary
 file. Default is \code{"spec"}, which will extract the final spectra, e.g.
 expressed in absorbance (named \code{AB} in Bruker OPUS programs). Possible
-additional values for the character vector supplied to \code{type} are \code{"spec_no_atm_comp"} (spectrum of the sample without compensation for atmospheric gases H\link{2}O and/or CO\link{2}),
+additional values for the character vector supplied to \code{type} are \code{"spec_no_atm_comp"} (spectrum of the sample without compensation for atmospheric gases, water vapor and/or carbon dioxide),
 \code{"sc_sample"} (single channel spectrum of the sample measurement),
 \code{"sc_ref"} (single channel spectrum of the reference measurement),
 \code{"ig_sample"} (interferogram of the sample measurement) and \code{"ig_ref"}

--- a/man/opus_read_raw.Rd
+++ b/man/opus_read_raw.Rd
@@ -12,7 +12,7 @@ opus_read_raw(rw, type = "spec", atm_comp_minus4offset = FALSE)
 \item{type}{Character vector of spectra types to extract from OPUS binary
 file. Default is \code{"spec"}, which will extract the final spectra, e.g.
 expressed in absorbance (named \code{AB} in Bruker OPUS programs). Possible
-additional values for the character vector supplied to \code{type} are \code{"spec_no_bc"} (spectrum of the sample without background correction),
+additional values for the character vector supplied to \code{type} are \code{"spec_no_atm_comp"} (spectrum of the sample without compensation for atmospheric gases H\link{2}O and/or CO\link{2}),
 \code{"sc_sample"} (single channel spectrum of the sample measurement),
 \code{"sc_ref"} (single channel spectrum of the reference measurement),
 \code{"ig_sample"} (interferogram of the sample measurement) and \code{"ig_ref"}
@@ -26,12 +26,12 @@ files. Default is \code{FALSE}.}
 a list of 10 elements:
 - \code{metadata}: a \code{data.frame} containing metadata from the OPUS file
 - \code{spec} If \code{"spec"} was requested in the \code{type} option, a matrix of the spectrum of the sample (otherwise set to \code{NULL}).
-- \code{spec_no_bc} If \code{"spec_no_bc"} was requested in the \code{type} option, a matrix of the spectrum of the sample without background correction (otherwise set to \code{NULL}).
+- \code{spec_no_atm_comp} If \code{"spec_no_atm_comp"} was requested in the \code{type} option, a matrix of the spectrum of the sample without atmospheric compensation (otherwise set to \code{NULL}).
 - \code{sc_sample} If \code{"sc_sample"} was requested in the \code{type} option, a matrix of the single channel spectrum of the sample (otherwise set to \code{NULL}).
 - \code{sc_ref} If \code{"sc_ref"} was requested in the \code{type} option, a matrix of the single channel spectrum of the reference (otherwise set to \code{NULL}).
 - \code{ig_sample} If \code{"ig_sample"} was requested in the \code{type} option, a matrix of the interferogram of the sample (otherwise set to \code{NULL}).
 - \code{ig_ref}  If \code{"ig_ref"} was requested in the \code{type} option, a matrix of the interferogram of the reference (otherwise set to \code{NULL}).
-- \code{wavenumbers} If \code{"spec"} or \code{"spec_no_bc"} was requested in the \code{type} option, a numeric vector of the wavenumbers of the spectrum of the sample (otherwise set to \code{NULL}).
+- \code{wavenumbers} If \code{"spec"} or \code{"spec_no_atm_comp"} was requested in the \code{type} option, a numeric vector of the wavenumbers of the spectrum of the sample (otherwise set to \code{NULL}).
 - \code{wavenumbers_sc_sample} If \code{"sc_sample"} was requested in the \code{type} option, a numeric vector of the wavenumbers of the single channel spectrum of the sample (otherwise set to \code{NULL}).
 - \code{wavenumbers_sc_ref} If \code{"sc_ref"} was requested in the \code{type} option, a numeric vector of the wavenumbers of the single channel spectrum of the reference (otherwise set to \code{NULL}).
 }


### PR DESCRIPTION
Hi Pierre, here is the mentioned change as discussed in private. 
Cheers,
Philipp